### PR TITLE
fix: include bin directory in published package (for Yarn Berry 4.x compatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "ibexa-generate-tsconfig": "./bin/generate.tsconfig.mjs"
   },
   "files": [
-    "tsconfig.json"
+    "tsconfig.json",
+    "bin"
   ],
   "devDependencies": {
     "@ibexa/eslint-config": "https://github.com/ibexa/eslint-config-ibexa.git#~v2.0.0"


### PR DESCRIPTION
Fixes MODULE_NOT_FOUND error when running `ibexa-generate-tsconfig` with Yarn Berry (4.x).

The `bin` directory was not being included in the published package because the `files` field in package.json only specified `tsconfig.json`. While older Yarn versions (1.x) included all files from Git dependencies, Yarn Berry (4.x) strictly respects the `files` field, causing the binary defined in the `bin` field to be missing when installed.

**Changes:**
- Added `"bin"` to the `files` array in package.json

**Impact:**
Resolves installation failures with Yarn Berry where the generate.tsconfig.mjs script could not be found. Yarn 1.x installations are unaffected.