### PR TITLE
IBX-12116: Included the other bundles' global declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibexa/ts-config",
   "description": "Default Ibexa TypeScript configuration",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [],
   "main": "./tsconfig.json",
   "browser": "./tsconfig.json",

--- a/src/TSConfigIbexaGenerator.mjs
+++ b/src/TSConfigIbexaGenerator.mjs
@@ -239,11 +239,14 @@ export default class TSConfigIbexaGenerator {
         ]
     }
 
+    getGlobalTypesPath = () => this.getPath(this.getIbexaVendorPath('*/src/bundle/Resources/types/**/*.d.ts', true));
+
     generateBundleTSConfigContent = async () => {
         const configFileContent = {
             include: [
                 'src/bundle/**/*.ts',
                 'src/bundle/**/*.tsx',
+                this.getGlobalTypesPath(),
             ],
         };
 


### PR DESCRIPTION
| :ticket: Issue | IBX-12116 |
|----------------|----------|

#### Description:
A bundle's generated tsconfig listed only its own sources, so ambient declarations from the other Ibexa bundles never entered the program — nothing imports them, and path aliases only pull in modules that are imported. Reading `window.ibexa.adminUiConfig` failed even though `admin-ui` declares it.

The vendor path is resolved from the project root, so one entry covers both a bundle inside a DXP install and a standalone checkout.